### PR TITLE
Release v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-table-align",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "textlint rule that check table align.",
   "keywords": [
     "textlintrule"


### PR DESCRIPTION
release v1.0.0

## What's Changed

- Support textlint v14.

### Breaking Changes

- Require Node.js 18.14.0 or later.

https://github.com/ohakutsu/textlint-rule-table-align/compare/v0.1.0...4edb63f58fa01936f381958f74f3f316523e394e